### PR TITLE
fix: "config changes require an extension restart"

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,6 @@ The following options are available for configuration:
 - `prohe.vibrationStageLength`: Duration (in milliseconds) of each stage of vibration
   - Longer stage length will mean a longer ramp up time to get to maximum vibration
 
-## Known Issues
-
-- Changes to the configuration require an extension restart before taking effect
-
 ## Support
 
 For any issues or questions, please visit the [PROHE GitHub repository](https://github.com/UncensorPat/prohe).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prohe",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prohe",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "buttplug": "^3.1.1",
         "filereader": "^0.10.3",
@@ -3376,9 +3376,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.76.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
+      "integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -6113,9 +6113,9 @@
       }
     },
     "webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.76.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
+      "integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",


### PR DESCRIPTION
fixing known issue:

`Changes to the configuration require an extension restart before taking effect`

now checks the config during every vibration update, no longer needing a full extension restart when adjusting settings. 